### PR TITLE
feat: ログインページ機能の実装

### DIFF
--- a/apps/web/app/login/page.tsx
+++ b/apps/web/app/login/page.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useState } from 'react';
+import { signIn } from 'next-auth/react';
+import { useRouter } from 'next/navigation';
+
+export default function LoginPage() {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const router = useRouter();
+
+  const handleLogin = async () => {
+    const result = await signIn('credentials', {
+      redirect: false,
+      username,
+      password,
+    });
+
+    if (result?.ok) {
+      router.push('/');
+    } else {
+      alert('IDまたはパスワードが正しくありません');
+    }
+  };
+
+  return (
+    <div style={{ maxWidth: '400px', margin: '50px auto', padding: '20px', border: '1px solid #ccc', borderRadius: '5px' }}>
+      <h1>Login</h1>
+      <div style={{ marginBottom: '10px' }}>
+        <label>
+          Username:
+          <input
+            type="text"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            style={{ width: '100%', padding: '8px', boxSizing: 'border-box' }}
+          />
+        </label>
+      </div>
+      <div style={{ marginBottom: '20px' }}>
+        <label>
+          Password:
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            style={{ width: '100%', padding: '8px', boxSizing: 'border-box' }}
+          />
+        </label>
+      </div>
+      <button
+        onClick={handleLogin}
+        style={{ width: '100%', padding: '10px', backgroundColor: '#0070f3', color: 'white', border: 'none', borderRadius: '5px', cursor: 'pointer' }}
+      >
+        Login
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
このコミットは、`/login` に新しいログインページを導入します。

- `apps/web/app/login/page.tsx` を作成し、ログインのルートを処理します。
- `useState` を使用して、ユーザー名とパスワードの入力を管理します。
- 'credentials' プロバイダーで `next-auth/react` の `signIn` 関数を呼び出すハンドラーを実装します。
- `next/navigation` の `useRouter` を使用して、ログイン成功時にユーザーをホームページ（'/'）にリダイレクトします。
- ログイン失敗時にブラウザのアラートを表示します。