### PR TITLE
feat: Add API route to record NFC stamp

### DIFF
--- a/apps/web/app/api/nfc/record/route.ts
+++ b/apps/web/app/api/nfc/record/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '@/app/api/auth/[...nextauth]/route';
+import { recordNfcStamp } from 'packages/api/src/nfcService';
+import { z } from 'zod';
+
+const recordSchema = z.object({
+  machineId: z.string(),
+  latitude: z.number(),
+  longitude: z.number(),
+  workDescription: z.string(),
+});
+
+export async function POST(request: Request) {
+  try {
+    const session = await getServerSession(authOptions);
+
+    if (!session || !session.user || !session.user.id) {
+      return NextResponse.json({ message: 'Unauthorized' }, { status: 401 });
+    }
+    const userId = session.user.id;
+
+    const body = await request.json();
+    const validation = recordSchema.safeParse(body);
+
+    if (!validation.success) {
+      return NextResponse.json({ message: 'Invalid request body', errors: validation.error.issues }, { status: 400 });
+    }
+
+    const { machineId, latitude, longitude, workDescription } = validation.data;
+
+    const result = await recordNfcStamp({
+      userId,
+      machineId,
+      latitude,
+      longitude,
+      workDescription,
+    });
+
+    return NextResponse.json(result.fields, { status: 200 });
+
+  } catch (error) {
+    console.error('API Error in /api/nfc/record:', error);
+    const errorMessage = error instanceof Error ? error.message : 'An unexpected error occurred';
+
+    if (errorMessage.includes('not found')) {
+      return NextResponse.json({ message: errorMessage }, { status: 404 });
+    }
+
+    return NextResponse.json({ message: 'Internal Server Error', error: errorMessage }, { status: 500 });
+  }
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -22,7 +22,8 @@
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "tailwind-merge": "^3.3.1",
-    "tailwindcss-animate": "^1.0.7"
+    "tailwindcss-animate": "^1.0.7",
+    "zod": "^4.1.5"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,6 +52,9 @@ importers:
       tailwindcss-animate:
         specifier: ^1.0.7
         version: 1.0.7(tailwindcss@4.1.13)
+      zod:
+        specifier: ^4.1.5
+        version: 4.1.5
     devDependencies:
       '@eslint/eslintrc':
         specifier: ^3
@@ -2315,6 +2318,9 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zod@4.1.5:
+    resolution: {integrity: sha512-rcUUZqlLJgBC33IT3PNMgsCq6TzLQEG/Ei/KTCU0PedSWRMAXoOUN+4t/0H+Q8bdnLPdqUYnvboJT0bn/229qg==}
 
 snapshots:
 
@@ -4706,3 +4712,5 @@ snapshots:
   yallist@5.0.0: {}
 
   yocto-queue@0.1.0: {}
+
+  zod@4.1.5: {}


### PR DESCRIPTION
This commit introduces a new API route handler at POST /api/nfc/record.

The handler performs the following actions:
- Authenticates the user using next-auth.
- Validates the request body for machineId, latitude, longitude, and workDescription using Zod.
- Calls the `recordNfcStamp` service function to persist the data in Airtable.
- Returns the created record on success or an appropriate error response.