### PR TITLE
feat(nfc): implement API call for clock-in/out

### DIFF
--- a/apps/web/components/nfc/ClockInForm.tsx
+++ b/apps/web/components/nfc/ClockInForm.tsx
@@ -2,6 +2,7 @@
 
 import * as React from "react"
 import { useState } from "react"
+import { useRouter } from "next/navigation"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import {
@@ -19,6 +20,7 @@ interface ClockInFormProps {
 }
 
 export function ClockInForm({ machineid, workOptions }: ClockInFormProps) {
+  const router = useRouter()
   const [selectedWork, setSelectedWork] = useState<string>("")
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -61,14 +63,15 @@ export function ClockInForm({ machineid, workOptions }: ClockInFormProps) {
         throw new Error(errorData.message || "打刻に失敗しました。")
       }
 
-      // Success, reload the page to show the clock-out view
-      window.location.reload()
+      alert("記録しました")
+      router.refresh()
     } catch (err) {
       if (err instanceof Error) {
         setError(err.message)
       } else {
         setError("不明なエラーが発生しました。")
       }
+      alert("エラーが発生しました")
     } finally {
       setIsSubmitting(false)
     }

--- a/apps/web/components/nfc/ClockOutView.tsx
+++ b/apps/web/components/nfc/ClockOutView.tsx
@@ -3,6 +3,7 @@
 import * as React from "react"
 import { useState } from "react"
 import Image from "next/image"
+import { useRouter } from "next/navigation"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 
@@ -33,6 +34,7 @@ const InfoLine: React.FC<InfoLineProps> = ({ icon, label, value }) => (
 )
 
 export function ClockOutView({ machineid, clockInInfo }: ClockOutViewProps) {
+  const router = useRouter()
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -69,14 +71,15 @@ export function ClockOutView({ machineid, clockInInfo }: ClockOutViewProps) {
         throw new Error(errorData.message || "退勤に失敗しました。")
       }
 
-      // Success, reload the page to show the clock-in form
-      window.location.reload()
+      alert("記録しました")
+      router.refresh()
     } catch (err) {
       if (err instanceof Error) {
         setError(err.message)
       } else {
         setError("不明なエラーが発生しました。")
       }
+      alert("エラーが発生しました")
     } finally {
       setIsSubmitting(false)
     }


### PR DESCRIPTION
Modified `ClockInForm.tsx` and `ClockOutView.tsx` to implement the final step of the NFC clock-in/out feature.

- Replaced `window.location.reload()` with `router.refresh()` from `next/navigation` for a smoother UX when updating the view after a successful API call.
- Added `alert()` notifications to provide clear feedback to the user upon success ("記録しました") or failure ("エラーが発生しました") of the clock-in/out action.

This completes the client-side logic for recording timestamps.